### PR TITLE
Use a more reliable source of the static files URL

### DIFF
--- a/explorer/templatetags/vite.py
+++ b/explorer/templatetags/vite.py
@@ -2,12 +2,13 @@ import os
 
 from django import template
 from django.conf import settings
+from django.contrib.staticfiles.storage import staticfiles_storage
 from django.utils.safestring import mark_safe
 from explorer import app_settings, get_version
 
 register = template.Library()
 
-VITE_OUTPUT_DIR = f"{settings.STATIC_URL}explorer/"
+VITE_OUTPUT_DIR = staticfiles_storage.url("explorer/")
 VITE_DEV_DIR = "explorer/src/"
 VITE_SERVER_HOST = getattr(settings, "VITE_SERVER_HOST", "localhost")
 VITE_SERVER_PORT = getattr(settings, "VITE_SERVER_PORT", "5173")


### PR DESCRIPTION
I have a case when SQL explorer pages don't render correctly because paths of all static files are wrong.

django-storages is used and [`AWS_LOCATION`](https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html#:~:text=location%20or%20AWS_LOCATION) is set, so actual paths are prefixed.
The SQL explorer uses `settings.STATIC_URL` to construct URLs of static files, but `settings.STATIC_URL` doesn't contain the prefix in the described configuration.

There may be other cases when storage classes change URLs, let's build the URLs using a configured Django storage.